### PR TITLE
Fixes for issues #13 (C++11), #15 (test name warning)

### DIFF
--- a/makefile
+++ b/makefile
@@ -5,6 +5,9 @@ LOGIN ?= eie2ugs
 CPPFLAGS += -W -Wall -g
 CPPFLAGS += -I include
 
+CFLAGS	 += -std=c99
+CXXFLAGS += -std=c++11
+
 # Force the inclusion of C++ standard libraries
 LDLIBS += -lstdc++
 

--- a/src/shared/mips_test_framework.cpp
+++ b/src/shared/mips_test_framework.cpp
@@ -33,7 +33,7 @@ struct instr_info_t
 
 static const instr_info_t sg_instructionsArray[]=
 {
-    {"<internal>", "Tests of things other than intructions."},
+    {"<INTERNAL>", "Tests of things other than intructions."},
     {"ADD","Add (with overflow)"},
     {"ADDI","Add immediate (with overflow)"},
     {"ADDIU","Add immediate unsigned (no overflow)"},


### PR DESCRIPTION
Added compiler flags to comply with [documented environments](https://github.com/m8pple/arch2-2014-cw1#compilation-environment) C99, C++11.
